### PR TITLE
Add CASSIA to Natural Science Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Autonomous research workflows for natural science discovery (e.g., chemistry, bi
 *   **Towards an AI co-scientist** [![arXiv](https://img.shields.io/badge/arXiv-2502.18864-B31B1B.svg)](https://arxiv.org/pdf/2502.18864) - *Gottweis et al. (2025.02)*
 *   **GenoMAS: A Multi-Agent Framework for Scientific Discovery via Code-Driven Gene Expression Analysis** [![arXiv](https://img.shields.io/badge/arXiv-2507.21035-B31B1B.svg)](https://arxiv.org/pdf/2507.21035) - *Liu et al. (2025.07)*
 *   **Automated Algorithmic Discovery for Gravitational-Wave Detection Guided by LLM-Informed Evolutionary Monte Carlo Tree Search** [![arXiv](https://img.shields.io/badge/arXiv-2508.03661-B31B1B.svg)](https://arxiv.org/pdf/2508.03661) - *Wang and Zeng (2025.08)*
+*   **CASSIA: a multi-agent large language model for automated and interpretable cell annotation** [![DOI](https://img.shields.io/badge/DOI-10.1038/s41467--025--67084--x-blue.svg)](https://www.nature.com/articles/s41467-025-67084-x) - *Xie et al. (2025.12)*
 
 ### General Research
 


### PR DESCRIPTION
Adds **CASSIA** under **Level 2: LLM as Analyst → Natural Science Research** (chronological, 2025.12).

CASSIA (Xie et al., *Nature Communications* 2025, [https://www.nature.com/articles/s41467-025-67084-x](https://www.nature.com/articles/s41467-025-67084-x)) is a multi-agent large language model for automated, reference-free, and interpretable cell-type annotation of single-cell RNA-seq data, with dedicated agents for annotation, validation, quality scoring, and reporting. Peer-reviewed; open source (MIT); repo https://github.com/ElliotXie/CASSIA.
